### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/paulstaab/feedfront/security/code-scanning/2](https://github.com/paulstaab/feedfront/security/code-scanning/2)

To address this issue, we should add an explicit `permissions` block to the `test` job in `.github/workflows/ci.yml`. Since the steps in the `test` job do not require any write permissions and only need to read the repository contents (mainly to check out the code), we can set `permissions: { contents: read }` for this job. This aligns with the principle of least privilege and prevents the job from getting unnecessary write or admin access. This change should be made by inserting the `permissions:` block directly after the `runs-on:` key of the `test` job. No extra methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
