### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paulstaab/feedfront/security/code-scanning/1](https://github.com/paulstaab/feedfront/security/code-scanning/1)

The best way to fix this problem is to explicitly declare a `permissions` block for those jobs that do not currently set one (`lint` and `test`). Given these jobs only check out code, install dependencies, lint, and run tests (i.e., they do not need to write to the repo or use the API for anything, including checks, issues, PRs, etc.), the minimum required permission is `contents: read`. This can be set per-job or at the root level of the workflow for all jobs, but since the `release` job already sets its own block, we can set the default at the top (root) with `contents: read`, allowing `release` to override as needed.

**Summary of actions:**
- Insert a `permissions: contents: read` block at the root level of `.github/workflows/ci.yml` (after `name` and before `on`).  
  - This applies to all jobs that don't explicitly set a `permissions` block (here: `lint` and `test`).
- No other code or dependencies need to be modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
