### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/paulstaab/feedfront/security/code-scanning/1](https://github.com/paulstaab/feedfront/security/code-scanning/1)

To fix the issue, an explicit `permissions` block should be added to the `lint` job. Based on the steps included, the `lint` job interacts only with repository code (cloning and running local commands), so it only requires read access to repository contents. Add a `permissions` section to the `lint` job, directly under `runs-on: ubuntu-latest`, with `contents: read`, matching the pattern used in the `test` job. No other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
