### PR TITLE
feat: implement feed management and login flow hooks

### DIFF
--- a/src/app/feeds/page.tsx
+++ b/src/app/feeds/page.tsx
@@ -12,50 +12,11 @@ import {
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  Fragment,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ButtonHTMLAttributes,
-  type SubmitEvent,
-} from 'react';
+import { Fragment, Suspense, type ButtonHTMLAttributes } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/hooks/useAuth';
-import { createFeed, deleteFeed, getFeeds, moveFeed, renameFeed } from '@/lib/api/feeds';
-import { createFolder, deleteFolder, getFolders, renameFolder } from '@/lib/api/folders';
-import { getItems } from '@/lib/api/items';
-import { AuthenticationError } from '@/lib/api/client';
-import { formatError } from '@/lib/utils/errorFormatter';
-import { ItemFilterType, type Feed, type Folder } from '@/types';
-import {
-  buildFeedManagementGroups,
-  formatExactLocalDateTime,
-  compareLabels,
-  formatRelativeDateTime,
-  type FeedManagementGroup,
-} from '@/lib/feeds/feedManagement';
-
-interface FeedManagementData {
-  folders: Folder[];
-  feeds: Feed[];
-}
-
-/**
- * Removes a feed activity entry without mutating the source record.
- */
-function omitLatestArticleDate(
-  entries: Record<number, number | null>,
-  feedId: number,
-): Record<number, number | null> {
-  return Object.fromEntries(
-    Object.entries(entries).filter(([entryId]) => Number(entryId) !== feedId),
-  ) as Record<number, number | null>;
-}
+import { formatExactLocalDateTime, formatRelativeDateTime } from '@/lib/feeds/feedManagement';
+import { FullscreenStatus } from '@/components/ui/FullscreenStatus';
+import { useFeedManagementPage } from '@/hooks/useFeedManagementPage';
 
 interface FeedActionButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
@@ -96,410 +57,61 @@ function FeedActionButton({
 }
 
 /**
- * Returns true when keyboard shortcuts should be ignored because focus is inside an editable field.
- */
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-
-  const tagName = target.tagName;
-  return (
-    target.isContentEditable ||
-    tagName === 'INPUT' ||
-    tagName === 'TEXTAREA' ||
-    tagName === 'SELECT'
-  );
-}
-
-/**
  * Feed management route for subscriptions and folders.
  */
 function FeedManagementContent() {
-  const router = useRouter();
-  const { isAuthenticated, isInitializing, logout } = useAuth();
-  const createFeedDialogRef = useRef<HTMLDialogElement>(null);
-  const createFolderDialogRef = useRef<HTMLDialogElement>(null);
-  const moveFeedDialogRef = useRef<HTMLDialogElement>(null);
-
-  const [data, setData] = useState<FeedManagementData>({ folders: [], feeds: [] });
-  const [latestArticleDates, setLatestArticleDates] = useState<Record<number, number | null>>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [busyLabel, setBusyLabel] = useState<string | null>(null);
-  const [pageError, setPageError] = useState<string | null>(null);
-  const [mutationError, setMutationError] = useState<string | null>(null);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [newFeedUrl, setNewFeedUrl] = useState('');
-  const [newFeedFolderId, setNewFeedFolderId] = useState('');
-  const [newFolderName, setNewFolderName] = useState('');
-  const [editingFolderId, setEditingFolderId] = useState<number | null>(null);
-  const [editingFolderName, setEditingFolderName] = useState('');
-  const [editingFeedId, setEditingFeedId] = useState<number | null>(null);
-  const [editingFeedTitle, setEditingFeedTitle] = useState('');
-  const [moveFeedId, setMoveFeedId] = useState<number | null>(null);
-  const [moveFeedTitle, setMoveFeedTitle] = useState('');
-  const [moveFeedFolderId, setMoveFeedFolderId] = useState('');
-
-  const sortedFolders = useMemo(
-    () => [...data.folders].sort((left, right) => compareLabels(left.name, right.name)),
-    [data.folders],
-  );
-
-  const groups = useMemo<FeedManagementGroup[]>(
-    () => buildFeedManagementGroups(data.folders, data.feeds, latestArticleDates),
-    [data.feeds, data.folders, latestArticleDates],
-  );
-  const handleRequestError = useCallback(
-    (error: unknown, fallbackMessage: string) => {
-      if (error instanceof AuthenticationError) {
-        logout();
-        router.push('/login');
-        return fallbackMessage;
-      }
-
-      const formatted = formatError(error);
-      return [formatted.message || fallbackMessage, formatted.action].filter(Boolean).join(' ');
-    },
-    [logout, router],
-  );
-
-  const openCreateFeedDialog = useCallback(() => {
-    createFeedDialogRef.current?.showModal();
-  }, []);
-
-  const closeCreateFeedDialog = useCallback(() => {
-    createFeedDialogRef.current?.close();
-  }, []);
-
-  const openMoveFeedDialog = useCallback((feed: Feed) => {
-    setMoveFeedId(feed.id);
-    setMoveFeedTitle(feed.title);
-    setMoveFeedFolderId(feed.folderId === null ? '' : String(feed.folderId));
-    moveFeedDialogRef.current?.showModal();
-  }, []);
-
-  const resetMoveFeedDialog = useCallback(() => {
-    setMoveFeedId(null);
-    setMoveFeedTitle('');
-    setMoveFeedFolderId('');
-  }, []);
-
-  /**
-   * Refreshes lightweight "latest article date" metadata without blocking the main page render.
-   * Fetches a single batch of recent items across all feeds and derives the latest date per feed
-   * client-side to avoid an N+1 network pattern.
-   */
-  const refreshFeedActivity = useCallback(async (feeds: Feed[]) => {
-    if (feeds.length === 0) {
-      setLatestArticleDates({});
-      return;
-    }
-
-    try {
-      const items = await getItems({
-        type: ItemFilterType.ALL,
-        getRead: true,
-        batchSize: 200,
-      });
-
-      const datesByFeed: Record<number, number | null> = {};
-      for (const feed of feeds) {
-        datesByFeed[feed.id] = null;
-      }
-      for (const item of items) {
-        if (!(item.feedId in datesByFeed)) continue;
-        const current = datesByFeed[item.feedId];
-        if (current === null || item.pubDate > current) {
-          datesByFeed[item.feedId] = item.pubDate;
-        }
-      }
-
-      setLatestArticleDates(datesByFeed);
-    } catch {
-      setLatestArticleDates((current) => current);
-    }
-  }, []);
-
-  /**
-   * Loads folder and feed data while preserving the current view on refresh failures.
-   */
-  const refreshPageData = useCallback(
-    async (initialLoad = false) => {
-      if (initialLoad) {
-        setIsLoading(true);
-      } else {
-        setIsRefreshing(true);
-      }
-
-      try {
-        const [folders, feedsResponse] = await Promise.all([getFolders(), getFeeds()]);
-        setData({ folders, feeds: feedsResponse.feeds });
-        setPageError(null);
-        void refreshFeedActivity(feedsResponse.feeds);
-      } catch (error) {
-        const message = handleRequestError(error, 'Unable to load feed management data.');
-        setPageError(message);
-      } finally {
-        if (initialLoad) {
-          setIsLoading(false);
-        } else {
-          setIsRefreshing(false);
-        }
-      }
-    },
-    [handleRequestError, refreshFeedActivity],
-  );
-
-  useEffect(() => {
-    if (!isInitializing && !isAuthenticated) {
-      router.push('/login');
-      return;
-    }
-
-    if (!isInitializing && isAuthenticated) {
-      void refreshPageData(true);
-    }
-  }, [isAuthenticated, isInitializing, refreshPageData, router]);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== '+' && event.code !== 'NumpadAdd') {
-        return;
-      }
-
-      if (isEditableTarget(event.target)) {
-        return;
-      }
-
-      event.preventDefault();
-      openCreateFeedDialog();
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [openCreateFeedDialog]);
-
-  const runMutation = useCallback(
-    async (label: string, action: () => Promise<void>) => {
-      setBusyLabel(label);
-      setMutationError(null);
-      setStatusMessage(null);
-
-      try {
-        await action();
-        await refreshPageData(false);
-        return true;
-      } catch (error) {
-        const message = handleRequestError(error, `${label} failed.`);
-        setMutationError(message);
-        return false;
-      } finally {
-        setBusyLabel(null);
-      }
-    },
-    [handleRequestError, refreshPageData],
-  );
-
-  const handleSubscribe = async (event: SubmitEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const trimmedUrl = newFeedUrl.trim();
-    if (!trimmedUrl) {
-      setMutationError('Feed URL is required. Enter a valid RSS or Atom URL and try again.');
-      return;
-    }
-
-    await runMutation('Subscribe feed', async () => {
-      const folderId = newFeedFolderId ? Number(newFeedFolderId) : null;
-      const result = await createFeed(trimmedUrl, folderId);
-
-      setData((current) => ({
-        ...current,
-        feeds: [...current.feeds, result.feed],
-      }));
-      setLatestArticleDates((current) => ({
-        ...current,
-        [result.feed.id]: null,
-      }));
-      setNewFeedUrl('');
-      setNewFeedFolderId('');
-      closeCreateFeedDialog();
-      setStatusMessage(`Subscribed to ${result.feed.title}.`);
-    });
-  };
-
-  const handleCreateFolder = async (event: SubmitEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const trimmedName = newFolderName.trim();
-    if (!trimmedName) {
-      setMutationError('Folder name is required.');
-      return;
-    }
-
-    await runMutation('Create folder', async () => {
-      const createdFolder = await createFolder(trimmedName);
-      setData((current) => ({
-        ...current,
-        folders: [...current.folders, createdFolder],
-      }));
-      setNewFolderName('');
-      createFolderDialogRef.current?.close();
-      setStatusMessage(`Created folder ${createdFolder.name}.`);
-    });
-  };
-
-  const handleRenameFolder = async (folderId: number) => {
-    const trimmedName = editingFolderName.trim();
-    if (!trimmedName) {
-      setMutationError('Folder name is required.');
-      return;
-    }
-
-    await runMutation('Rename folder', async () => {
-      await renameFolder(folderId, trimmedName);
-      setData((current) => ({
-        ...current,
-        folders: current.folders.map((folder) =>
-          folder.id === folderId ? { ...folder, name: trimmedName } : folder,
-        ),
-      }));
-      setEditingFolderId(null);
-      setEditingFolderName('');
-      setStatusMessage(`Renamed folder to ${trimmedName}.`);
-    });
-  };
-
-  const handleDeleteFolder = async (folder: Folder) => {
-    const assignedFeeds = data.feeds.filter((feed) => feed.folderId === folder.id);
-    const assignedFeedCount = assignedFeeds.length;
-    const confirmed = window.confirm(
-      `Delete "${folder.name}"? This will unsubscribe ${String(assignedFeedCount)} feed${
-        assignedFeedCount === 1 ? '' : 's'
-      } currently assigned to the folder.`,
-    );
-
-    if (!confirmed) {
-      return;
-    }
-
-    await runMutation('Delete folder', async () => {
-      if (assignedFeeds.length > 0) {
-        const results = await Promise.allSettled(assignedFeeds.map((feed) => deleteFeed(feed.id)));
-
-        const deletedFeedIds = assignedFeeds
-          .filter((_, index) => results[index].status === 'fulfilled')
-          .map((feed) => feed.id);
-        const failedCount = results.filter((result) => result.status === 'rejected').length;
-
-        if (failedCount > 0) {
-          setData((current) => ({
-            ...current,
-            feeds: current.feeds.filter((feed) => !deletedFeedIds.includes(feed.id)),
-          }));
-          setLatestArticleDates((current) =>
-            deletedFeedIds.reduce(
-              (nextEntries, feedId) => omitLatestArticleDate(nextEntries, feedId),
-              current,
-            ),
-          );
-          throw new Error(
-            `Unable to unsubscribe ${String(failedCount)} feed${failedCount === 1 ? '' : 's'} from "${folder.name}". The folder was not deleted.`,
-          );
-        }
-      }
-
-      await deleteFolder(folder.id);
-      setData((current) => ({
-        folders: current.folders.filter((entry) => entry.id !== folder.id),
-        feeds: current.feeds.filter((feed) => feed.folderId !== folder.id),
-      }));
-      setLatestArticleDates((current) =>
-        assignedFeeds.reduce(
-          (nextEntries, feed) => omitLatestArticleDate(nextEntries, feed.id),
-          current,
-        ),
-      );
-      setStatusMessage(`Deleted folder ${folder.name}.`);
-    });
-  };
-
-  const handleRenameFeed = async (feedId: number) => {
-    const trimmedTitle = editingFeedTitle.trim();
-    if (!trimmedTitle) {
-      setMutationError('Feed name is required.');
-      return;
-    }
-
-    await runMutation('Rename feed', async () => {
-      await renameFeed(feedId, trimmedTitle);
-      setData((current) => ({
-        ...current,
-        feeds: current.feeds.map((feed) =>
-          feed.id === feedId ? { ...feed, title: trimmedTitle } : feed,
-        ),
-      }));
-      setEditingFeedId(null);
-      setEditingFeedTitle('');
-      setStatusMessage(`Renamed feed to ${trimmedTitle}.`);
-    });
-  };
-
-  const handleMoveFeed = async (feedId: number, folderIdValue: string) => {
-    const folderId = folderIdValue ? Number(folderIdValue) : null;
-
-    return runMutation('Move feed', async () => {
-      await moveFeed(feedId, folderId);
-      setData((current) => ({
-        ...current,
-        feeds: current.feeds.map((feed) => (feed.id === feedId ? { ...feed, folderId } : feed)),
-      }));
-      setStatusMessage('Moved feed successfully.');
-    });
-  };
-
-  const handleMoveFeedSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (moveFeedId === null) {
-      return;
-    }
-
-    const moved = await handleMoveFeed(moveFeedId, moveFeedFolderId);
-    if (moved) {
-      moveFeedDialogRef.current?.close();
-      resetMoveFeedDialog();
-    }
-  };
-
-  const handleDeleteFeed = async (feed: Feed) => {
-    const confirmed = window.confirm(`Unsubscribe "${feed.title}"?`);
-    if (!confirmed) {
-      return;
-    }
-
-    await runMutation('Delete feed', async () => {
-      await deleteFeed(feed.id);
-      setData((current) => ({
-        ...current,
-        feeds: current.feeds.filter((entry) => entry.id !== feed.id),
-      }));
-      setLatestArticleDates((current) => omitLatestArticleDate(current, feed.id));
-      setStatusMessage(`Unsubscribed from ${feed.title}.`);
-    });
-  };
+  const {
+    isAuthenticated,
+    isInitializing,
+    isLoading,
+    isRefreshing,
+    data,
+    groups,
+    sortedFolders,
+    busyLabel,
+    pageError,
+    mutationError,
+    statusMessage,
+    createFeedDialogRef,
+    createFolderDialogRef,
+    moveFeedDialogRef,
+    newFeedUrl,
+    setNewFeedUrl,
+    newFeedFolderId,
+    setNewFeedFolderId,
+    newFolderName,
+    setNewFolderName,
+    editingFolderId,
+    setEditingFolderId,
+    editingFolderName,
+    setEditingFolderName,
+    editingFeedId,
+    setEditingFeedId,
+    editingFeedTitle,
+    setEditingFeedTitle,
+    moveFeedTitle,
+    moveFeedFolderId,
+    setMoveFeedFolderId,
+    openCreateFeedDialog,
+    closeCreateFeedDialog,
+    openMoveFeedDialog,
+    resetMoveFeedDialog,
+    refreshPageData,
+    handleSubscribe,
+    handleCreateFolder,
+    handleRenameFolder,
+    handleDeleteFolder,
+    handleRenameFeed,
+    handleMoveFeedSubmit,
+    handleDeleteFeed,
+  } = useFeedManagementPage();
 
   if (isInitializing || isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[hsl(var(--color-surface))]">
-        <div className="inline-flex items-center gap-3 text-[hsl(var(--color-text-secondary))]">
-          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-[hsl(var(--color-primary))]" />
-          <span>Loading feed management...</span>
-        </div>
-      </div>
+      <FullscreenStatus
+        message="Loading feed management..."
+        className="bg-[hsl(var(--color-surface))]"
+      />
     );
   }
 
@@ -898,7 +510,8 @@ function FeedManagementContent() {
           <form
             method="dialog"
             onSubmit={(event) => {
-              void handleSubscribe(event);
+              event.preventDefault();
+              void handleSubscribe();
             }}
             className="space-y-6 p-6 sm:p-7"
           >
@@ -980,7 +593,8 @@ function FeedManagementContent() {
         >
           <form
             onSubmit={(event) => {
-              void handleMoveFeedSubmit(event);
+              event.preventDefault();
+              void handleMoveFeedSubmit();
             }}
             className="space-y-5 p-6"
           >
@@ -1040,7 +654,8 @@ function FeedManagementContent() {
           <form
             method="dialog"
             onSubmit={(event) => {
-              void handleCreateFolder(event);
+              event.preventDefault();
+              void handleCreateFolder();
             }}
             className="space-y-5 p-6"
           >

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { Suspense, useState } from 'react';
-import type { SubmitEvent } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useAuth } from '@/hooks/useAuth';
-import { getVersion } from '@/lib/api/version';
-import { NetworkError, ApiError } from '@/lib/api/client';
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useAuthGuard } from '@/hooks/useAuthGuard';
+import { LoginStep, useLoginFlow } from '@/hooks/useLoginFlow';
+import { FullscreenStatus } from '@/components/ui/FullscreenStatus';
 
 /**
  * Multi-step login wizard
@@ -18,161 +17,31 @@ import { NetworkError, ApiError } from '@/lib/api/client';
  * Phase 3b: Enhanced with /version endpoint connectivity check
  */
 
-enum LoginStep {
-  SERVER_URL = 1,
-  VALIDATING_URL = 2,
-  CREDENTIALS = 3,
-  AUTHENTICATING = 4,
-}
-
 function LoginContent() {
-  const router = useRouter();
   const searchParams = useSearchParams();
-  const { login, error } = useAuth();
+  const { isInitializing } = useAuthGuard({ requireAuth: false });
   const isPlain = searchParams.get('plain') === '1';
+  const {
+    step,
+    serverUrl,
+    setServerUrl,
+    username,
+    setUsername,
+    password,
+    setPassword,
+    rememberDevice,
+    setRememberDevice,
+    validationError,
+    authError,
+    handleServerUrlSubmit,
+    handleCredentialsSubmit,
+    handlePlainSubmit,
+    handleBack,
+  } = useLoginFlow();
 
-  const [step, setStep] = useState<LoginStep>(LoginStep.SERVER_URL);
-  const [serverUrl, setServerUrl] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [rememberDevice, setRememberDevice] = useState(false);
-  const [validationError, setValidationError] = useState<string | null>(null);
-
-  // Step 1: Validate server URL and check connectivity
-  const handleServerUrlSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setValidationError(null);
-
-    const trimmedUrl = serverUrl.trim();
-
-    if (!trimmedUrl) {
-      setValidationError('Server URL is required');
-      return;
-    }
-
-    // Check HTTPS requirement
-    if (!trimmedUrl.startsWith('https://')) {
-      setValidationError('Server URL must use HTTPS');
-      return;
-    }
-
-    // Basic URL validation
-    try {
-      new URL(trimmedUrl);
-    } catch {
-      setValidationError('Please enter a valid URL');
-      return;
-    }
-
-    // Check server connectivity using /version endpoint
-    setStep(LoginStep.VALIDATING_URL);
-
-    try {
-      await getVersion(trimmedUrl);
-
-      // Server is reachable, advance to credentials step
-      setStep(LoginStep.CREDENTIALS);
-    } catch (err) {
-      // Handle connectivity errors
-      setStep(LoginStep.SERVER_URL);
-
-      if (err instanceof NetworkError) {
-        // Display the detailed NetworkError message (includes CORS-specific info)
-        setValidationError(err.message);
-      } else if (err instanceof ApiError) {
-        if (err.status === 404) {
-          setValidationError('Server not found or invalid API endpoint. Please verify the URL.');
-        } else if (err.status >= 500) {
-          setValidationError('Server error. Please try again later.');
-        } else {
-          setValidationError(`Server returned error: ${err.statusText}`);
-        }
-      } else {
-        setValidationError('Unable to validate server. Please check your connection.');
-      }
-    }
-  };
-
-  // Step 2: Submit credentials
-  const handleCredentialsSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setValidationError(null);
-
-    if (!username.trim()) {
-      setValidationError('Username is required');
-      return;
-    }
-
-    if (!password) {
-      setValidationError('Password is required');
-      return;
-    }
-
-    setStep(LoginStep.AUTHENTICATING);
-
-    try {
-      await login(serverUrl, username, password, rememberDevice);
-
-      // Redirect to timeline on success
-      router.push('/timeline');
-    } catch (err) {
-      // Stay on credentials step to allow retry
-      setStep(LoginStep.CREDENTIALS);
-      setValidationError(err instanceof Error ? err.message : 'Authentication failed');
-    }
-  };
-
-  const handlePlainSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setValidationError(null);
-
-    const trimmedUrl = serverUrl.trim();
-
-    if (!trimmedUrl) {
-      setValidationError('Server URL is required');
-      return;
-    }
-
-    if (!trimmedUrl.startsWith('https://')) {
-      setValidationError('Server URL must use HTTPS');
-      return;
-    }
-
-    try {
-      new URL(trimmedUrl);
-    } catch {
-      setValidationError('Please enter a valid URL');
-      return;
-    }
-
-    if (!username.trim()) {
-      setValidationError('Username is required');
-      return;
-    }
-
-    if (!password) {
-      setValidationError('Password is required');
-      return;
-    }
-
-    setStep(LoginStep.AUTHENTICATING);
-
-    try {
-      await getVersion(trimmedUrl);
-      await login(trimmedUrl, username, password, rememberDevice);
-      router.push('/timeline');
-    } catch (err) {
-      setStep(LoginStep.SERVER_URL);
-      setValidationError(err instanceof Error ? err.message : 'Authentication failed');
-    }
-  };
-
-  const handleBack = () => {
-    setValidationError(null);
-    if (step === LoginStep.CREDENTIALS) {
-      setStep(LoginStep.SERVER_URL);
-    }
-  };
+  if (isInitializing) {
+    return <FullscreenStatus message="Loading login..." />;
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 py-12">
@@ -206,16 +75,17 @@ function LoginContent() {
           </div>
 
           {/* Error display */}
-          {(validationError ?? error) && (
+          {(validationError ?? authError) && (
             <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-md">
-              <p className="text-sm text-red-800">{validationError ?? error}</p>
+              <p className="text-sm text-red-800">{validationError ?? authError}</p>
             </div>
           )}
 
           {isPlain && (
             <form
               onSubmit={(e) => {
-                void handlePlainSubmit(e);
+                e.preventDefault();
+                void handlePlainSubmit();
               }}
               className="space-y-6"
             >
@@ -302,7 +172,8 @@ function LoginContent() {
           {!isPlain && step === LoginStep.SERVER_URL && (
             <form
               onSubmit={(e) => {
-                void handleServerUrlSubmit(e);
+                e.preventDefault();
+                void handleServerUrlSubmit();
               }}
               className="space-y-6"
             >
@@ -348,7 +219,8 @@ function LoginContent() {
           {step === LoginStep.CREDENTIALS && (
             <form
               onSubmit={(e) => {
-                void handleCredentialsSubmit(e);
+                e.preventDefault();
+                void handleCredentialsSubmit();
               }}
               className="space-y-6"
             >
@@ -451,16 +323,7 @@ function LoginContent() {
  */
 export default function LoginPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 py-12">
-          <div className="inline-flex items-center gap-3 text-gray-600">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-            <span>Loading login...</span>
-          </div>
-        </div>
-      }
-    >
+    <Suspense fallback={<FullscreenStatus message="Loading login..." />}>
       <LoginContent />
     </Suspense>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,29 +3,26 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
+import { FullscreenStatus } from '@/components/ui/FullscreenStatus';
 
 /**
  * Home page that redirects to timeline or login based on auth state.
  */
 export default function HomePage() {
   const router = useRouter();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isInitializing } = useAuth();
 
   useEffect(() => {
+    if (isInitializing) {
+      return;
+    }
+
     if (isAuthenticated) {
       router.push('/timeline');
     } else {
       router.push('/login');
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, isInitializing, router]);
 
-  // Show loading state while redirecting
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center">
-        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mb-4"></div>
-        <p className="text-gray-600">Loading NewsBoxZero...</p>
-      </div>
-    </div>
-  );
+  return <FullscreenStatus message="Loading NewsBoxZero..." className="bg-transparent" />;
 }

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Suspense, useCallback, useEffect, useMemo, useRef, type CSSProperties } from 'react';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/hooks/useAuth';
+import { useAuthGuard } from '@/hooks/useAuthGuard';
 import { useTimeline } from '@/hooks/useTimeline';
 import { useFolderQueueDocking } from '@/hooks/useFolderQueueDocking';
 import { useArticlePopout } from '@/hooks/useArticlePopout';
@@ -20,14 +19,14 @@ import {
   markTimelineUpdateStart,
   markTimelineUpdateComplete,
 } from '@/lib/metrics/metricsClient';
+import { FullscreenStatus } from '@/components/ui/FullscreenStatus';
 
 /**
  * Timeline page content component
  * Extracted to wrap useSearchParams in Suspense
  */
 function TimelineContent() {
-  const router = useRouter();
-  const { isAuthenticated, isInitializing } = useAuth();
+  const { isAuthenticated, isInitializing } = useAuthGuard();
 
   // Mark cache load start before hook initialization
   useEffect(() => {
@@ -148,12 +147,6 @@ function TimelineContent() {
     unreadIdSet,
   ]);
 
-  useEffect(() => {
-    if (!isInitializing && !isAuthenticated) {
-      router.push('/login');
-    }
-  }, [isAuthenticated, isInitializing, router]);
-
   // Mark cache ready after hydration
   useEffect(() => {
     if (isHydrated) {
@@ -204,14 +197,7 @@ function TimelineContent() {
 
   // Show loading state while checking authentication
   if (isInitializing || !isHydrated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="inline-flex items-center gap-3 text-gray-600">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-          <span>Loading...</span>
-        </div>
-      </div>
-    );
+    return <FullscreenStatus message="Loading..." />;
   }
 
   if (!isAuthenticated) {
@@ -371,16 +357,7 @@ function TimelineContent() {
  */
 export default function TimelinePage() {
   return (
-    <Suspense
-      fallback={
-        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-          <div className="text-center">
-            <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mb-4"></div>
-            <p className="text-gray-600">Loading timeline...</p>
-          </div>
-        </div>
-      }
-    >
+    <Suspense fallback={<FullscreenStatus message="Loading timeline..." />}>
       <TimelineContent />
     </Suspense>
   );

--- a/src/components/ui/FullscreenStatus.tsx
+++ b/src/components/ui/FullscreenStatus.tsx
@@ -1,0 +1,18 @@
+interface FullscreenStatusProps {
+  message: string;
+  className?: string;
+}
+
+/**
+ * Renders a centered full-page loading state.
+ */
+export function FullscreenStatus({ message, className = 'bg-gray-50' }: FullscreenStatusProps) {
+  return (
+    <div className={`min-h-screen flex items-center justify-center ${className}`.trim()}>
+      <div className="inline-flex items-center gap-3 text-gray-600">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" />
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -4,7 +4,8 @@ import React, { createContext, useContext, useState, useCallback, useEffect } fr
 import { validateServerUrl, normalizeBaseUrl } from '@/lib/config/env';
 import { loadSession, storeSession, clearSession } from '@/lib/storage';
 import { validateCredentials } from '@/lib/api/client';
-import type { UserSessionConfig, StoredSession } from '@/types';
+import type { UserSessionConfig } from '@/types';
+import { encodeBasicCredentials, toStoredSession, toUserSessionConfig } from '@/lib/auth/session';
 
 interface AuthContextValue {
   /** Current session configuration (null if not authenticated) */
@@ -50,13 +51,6 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 /**
- * Encode username and password to Base64 for Basic auth
- */
-function encodeCredentials(username: string, password: string): string {
-  return btoa(`${username}:${password}`);
-}
-
-/**
  * Provides authentication state and actions to the app.
  */
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -70,18 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const loadStoredSession = () => {
       const stored = loadSession();
       if (stored) {
-        // Convert StoredSession to UserSessionConfig
-        const session: UserSessionConfig = {
-          baseUrl: stored.baseUrl,
-          username: stored.username,
-          credentials: stored.credentials,
-          rememberDevice: stored.rememberDevice,
-          viewMode: 'card',
-          sortOrder: 'newest',
-          showRead: false,
-          lastSyncAt: new Date().toISOString(),
-        };
-        setSession(session);
+        setSession(toUserSessionConfig(stored));
       }
       setIsInitializing(false);
     };
@@ -117,7 +100,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         // Encode credentials
-        const credentials = encodeCredentials(username, password);
+        const credentials = encodeBasicCredentials(username, password);
 
         // Validate credentials by calling the API with explicit credentials
         // This avoids relying on storage which hasn't been set yet
@@ -140,13 +123,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         };
 
         // Store session
-        const storedSession: StoredSession = {
-          baseUrl: newSession.baseUrl,
-          username: newSession.username,
-          credentials: newSession.credentials,
-          rememberDevice: newSession.rememberDevice,
-        };
-        storeSession(storedSession);
+        storeSession(toStoredSession(newSession));
 
         // Update state
         setSession(newSession);
@@ -181,13 +158,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       };
 
       // Store updated session
-      const storedSession: StoredSession = {
-        baseUrl: updatedSession.baseUrl,
-        username: updatedSession.username,
-        credentials: updatedSession.credentials,
-        rememberDevice: updatedSession.rememberDevice,
-      };
-      storeSession(storedSession);
+      storeSession(toStoredSession(updatedSession));
 
       // Update state
       setSession(updatedSession);

--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+
+interface UseAuthGuardOptions {
+  requireAuth?: boolean;
+  unauthenticatedRedirect?: string;
+  authenticatedRedirect?: string;
+}
+
+/**
+ * Centralizes route-level auth redirects and loading readiness.
+ */
+export function useAuthGuard(options: UseAuthGuardOptions = {}) {
+  const {
+    requireAuth = true,
+    unauthenticatedRedirect = '/login',
+    authenticatedRedirect = '/timeline',
+  } = options;
+  const router = useRouter();
+  const auth = useAuth();
+
+  useEffect(() => {
+    if (auth.isInitializing) {
+      return;
+    }
+
+    if (requireAuth && !auth.isAuthenticated) {
+      router.push(unauthenticatedRedirect);
+      return;
+    }
+
+    if (!requireAuth && auth.isAuthenticated) {
+      router.push(authenticatedRedirect);
+    }
+  }, [
+    auth.isAuthenticated,
+    auth.isInitializing,
+    authenticatedRedirect,
+    requireAuth,
+    router,
+    unauthenticatedRedirect,
+  ]);
+
+  return {
+    ...auth,
+    isReady: !auth.isInitializing && (requireAuth ? auth.isAuthenticated : !auth.isAuthenticated),
+  };
+}

--- a/src/hooks/useAutoMarkRead.ts
+++ b/src/hooks/useAutoMarkRead.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { ArticlePreview } from '@/types';
+import { createReadBatcher } from '@/lib/timeline/read-batching';
+
+interface UseAutoMarkReadOptions {
+  activeArticles: ArticlePreview[];
+  markItemRead: (itemId: number) => Promise<void>;
+  root?: Element | null;
+  topOffset?: number;
+  debounceMs?: number;
+}
+
+const OBSERVER_RE_ENABLE_DELAY_MS = 500;
+
+/**
+ * Observes article cards leaving the viewport and batches read-state updates.
+ */
+export function useAutoMarkRead({
+  activeArticles,
+  markItemRead,
+  root,
+  topOffset = 0,
+  debounceMs = 100,
+}: UseAutoMarkReadOptions) {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const elementsRef = useRef<Map<number, HTMLElement>>(new Map());
+  const seenRef = useRef<Set<number>>(new Set());
+  const batcherRef = useRef<ReturnType<typeof createReadBatcher> | null>(null);
+  const unreadMapRef = useRef<Map<number, boolean>>(new Map());
+  const observerDisabledRef = useRef(false);
+  const observerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    batcherRef.current?.clear();
+    batcherRef.current = createReadBatcher({
+      debounceMs,
+      onFlush: (ids) => {
+        ids.forEach((id) => {
+          void markItemRead(id);
+        });
+      },
+    });
+
+    return () => {
+      batcherRef.current?.clear();
+      batcherRef.current = null;
+      if (observerTimeoutRef.current !== null) {
+        clearTimeout(observerTimeoutRef.current);
+        observerTimeoutRef.current = null;
+      }
+    };
+  }, [debounceMs, markItemRead]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (observerDisabledRef.current) return;
+
+        entries.forEach((entry) => {
+          const target = entry.target as HTMLElement;
+          const id = Number(target.dataset.articleId);
+          if (!Number.isFinite(id)) return;
+
+          if (!entry.isIntersecting && entry.boundingClientRect.bottom <= 0) {
+            if (seenRef.current.has(id)) return;
+            if (unreadMapRef.current.get(id) === false) return;
+            seenRef.current.add(id);
+            batcherRef.current?.add(id);
+          }
+        });
+      },
+      {
+        root: root ?? null,
+        rootMargin: `${String(-Math.max(0, Math.round(topOffset)))}px 0px 0px 0px`,
+        threshold: [0],
+      },
+    );
+
+    observerRef.current = observer;
+    elementsRef.current.forEach((node) => {
+      observer.observe(node);
+    });
+
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+    };
+  }, [root, topOffset]);
+
+  useEffect(() => {
+    unreadMapRef.current = new Map(activeArticles.map((item) => [item.id, item.unread]));
+    const currentIds = new Set(activeArticles.map((item) => item.id));
+    for (const [id, element] of elementsRef.current.entries()) {
+      if (!currentIds.has(id)) {
+        observerRef.current?.unobserve(element);
+        elementsRef.current.delete(id);
+        seenRef.current.delete(id);
+      }
+    }
+  }, [activeArticles]);
+
+  const registerArticle = useCallback(
+    (id: number) => (node: HTMLElement | null) => {
+      if (!node) return;
+      node.dataset.articleId = String(id);
+      elementsRef.current.set(id, node);
+      observerRef.current?.observe(node);
+    },
+    [],
+  );
+
+  const disableObserverTemporarily = useCallback(() => {
+    observerDisabledRef.current = true;
+    if (observerTimeoutRef.current !== null) {
+      clearTimeout(observerTimeoutRef.current);
+    }
+    observerTimeoutRef.current = setTimeout(() => {
+      observerDisabledRef.current = false;
+      observerTimeoutRef.current = null;
+    }, OBSERVER_RE_ENABLE_DELAY_MS);
+  }, []);
+
+  return {
+    registerArticle,
+    disableObserverTemporarily,
+  };
+}

--- a/src/hooks/useFeedManagementPage.ts
+++ b/src/hooks/useFeedManagementPage.ts
@@ -1,0 +1,475 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthGuard } from '@/hooks/useAuthGuard';
+import { createFeed, deleteFeed, getFeeds, moveFeed, renameFeed } from '@/lib/api/feeds';
+import { createFolder, deleteFolder, getFolders, renameFolder } from '@/lib/api/folders';
+import { getItems } from '@/lib/api/items';
+import { AuthenticationError } from '@/lib/api/client';
+import { formatError } from '@/lib/utils/errorFormatter';
+import { ItemFilterType, type Feed, type Folder } from '@/types';
+import {
+  buildFeedManagementGroups,
+  compareLabels,
+  type FeedManagementGroup,
+} from '@/lib/feeds/feedManagement';
+
+interface FeedManagementData {
+  folders: Folder[];
+  feeds: Feed[];
+}
+
+/**
+ * Removes a feed activity entry without mutating the source record.
+ */
+function omitLatestArticleDate(
+  entries: Record<number, number | null>,
+  feedId: number,
+): Record<number, number | null> {
+  return Object.fromEntries(
+    Object.entries(entries).filter(([entryId]) => Number(entryId) !== feedId),
+  ) as Record<number, number | null>;
+}
+
+/**
+ * Returns true when keyboard shortcuts should be ignored because focus is inside an editable field.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = target.tagName;
+  return (
+    target.isContentEditable ||
+    tagName === 'INPUT' ||
+    tagName === 'TEXTAREA' ||
+    tagName === 'SELECT'
+  );
+}
+
+/**
+ * Owns feed-management page data loading, dialogs, and mutations.
+ */
+export function useFeedManagementPage() {
+  const router = useRouter();
+  const { isAuthenticated, isInitializing, logout } = useAuthGuard();
+  const createFeedDialogRef = useRef<HTMLDialogElement>(null);
+  const createFolderDialogRef = useRef<HTMLDialogElement>(null);
+  const moveFeedDialogRef = useRef<HTMLDialogElement>(null);
+
+  const [data, setData] = useState<FeedManagementData>({ folders: [], feeds: [] });
+  const [latestArticleDates, setLatestArticleDates] = useState<Record<number, number | null>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [busyLabel, setBusyLabel] = useState<string | null>(null);
+  const [pageError, setPageError] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [newFeedUrl, setNewFeedUrl] = useState('');
+  const [newFeedFolderId, setNewFeedFolderId] = useState('');
+  const [newFolderName, setNewFolderName] = useState('');
+  const [editingFolderId, setEditingFolderId] = useState<number | null>(null);
+  const [editingFolderName, setEditingFolderName] = useState('');
+  const [editingFeedId, setEditingFeedId] = useState<number | null>(null);
+  const [editingFeedTitle, setEditingFeedTitle] = useState('');
+  const [moveFeedId, setMoveFeedId] = useState<number | null>(null);
+  const [moveFeedTitle, setMoveFeedTitle] = useState('');
+  const [moveFeedFolderId, setMoveFeedFolderId] = useState('');
+
+  const sortedFolders = useMemo(
+    () => [...data.folders].sort((left, right) => compareLabels(left.name, right.name)),
+    [data.folders],
+  );
+  const groups = useMemo<FeedManagementGroup[]>(
+    () => buildFeedManagementGroups(data.folders, data.feeds, latestArticleDates),
+    [data.feeds, data.folders, latestArticleDates],
+  );
+
+  const handleRequestError = useCallback(
+    (error: unknown, fallbackMessage: string) => {
+      if (error instanceof AuthenticationError) {
+        logout();
+        router.push('/login');
+        return fallbackMessage;
+      }
+
+      const formatted = formatError(error);
+      return [formatted.message || fallbackMessage, formatted.action].filter(Boolean).join(' ');
+    },
+    [logout, router],
+  );
+
+  const openCreateFeedDialog = useCallback(() => {
+    createFeedDialogRef.current?.showModal();
+  }, []);
+
+  const closeCreateFeedDialog = useCallback(() => {
+    createFeedDialogRef.current?.close();
+  }, []);
+
+  const openMoveFeedDialog = useCallback((feed: Feed) => {
+    setMoveFeedId(feed.id);
+    setMoveFeedTitle(feed.title);
+    setMoveFeedFolderId(feed.folderId === null ? '' : String(feed.folderId));
+    moveFeedDialogRef.current?.showModal();
+  }, []);
+
+  const resetMoveFeedDialog = useCallback(() => {
+    setMoveFeedId(null);
+    setMoveFeedTitle('');
+    setMoveFeedFolderId('');
+  }, []);
+
+  const refreshFeedActivity = useCallback(async (feeds: Feed[]) => {
+    if (feeds.length === 0) {
+      setLatestArticleDates({});
+      return;
+    }
+
+    try {
+      const items = await getItems({
+        type: ItemFilterType.ALL,
+        getRead: true,
+        batchSize: 200,
+      });
+
+      const datesByFeed: Record<number, number | null> = {};
+      for (const feed of feeds) {
+        datesByFeed[feed.id] = null;
+      }
+      for (const item of items) {
+        if (!(item.feedId in datesByFeed)) continue;
+        const current = datesByFeed[item.feedId];
+        if (current === null || item.pubDate > current) {
+          datesByFeed[item.feedId] = item.pubDate;
+        }
+      }
+
+      setLatestArticleDates(datesByFeed);
+    } catch {
+      setLatestArticleDates((current) => current);
+    }
+  }, []);
+
+  const refreshPageData = useCallback(
+    async (initialLoad = false) => {
+      if (initialLoad) {
+        setIsLoading(true);
+      } else {
+        setIsRefreshing(true);
+      }
+
+      try {
+        const [folders, feedsResponse] = await Promise.all([getFolders(), getFeeds()]);
+        setData({ folders, feeds: feedsResponse.feeds });
+        setPageError(null);
+        void refreshFeedActivity(feedsResponse.feeds);
+      } catch (error) {
+        const message = handleRequestError(error, 'Unable to load feed management data.');
+        setPageError(message);
+      } finally {
+        if (initialLoad) {
+          setIsLoading(false);
+        } else {
+          setIsRefreshing(false);
+        }
+      }
+    },
+    [handleRequestError, refreshFeedActivity],
+  );
+
+  useEffect(() => {
+    if (!isInitializing && isAuthenticated) {
+      void refreshPageData(true);
+    }
+  }, [isAuthenticated, isInitializing, refreshPageData]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== '+' && event.code !== 'NumpadAdd') {
+        return;
+      }
+
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      openCreateFeedDialog();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [openCreateFeedDialog]);
+
+  const runMutation = useCallback(
+    async (label: string, action: () => Promise<void>) => {
+      setBusyLabel(label);
+      setMutationError(null);
+      setStatusMessage(null);
+
+      try {
+        await action();
+        await refreshPageData(false);
+        return true;
+      } catch (error) {
+        const message = handleRequestError(error, `${label} failed.`);
+        setMutationError(message);
+        return false;
+      } finally {
+        setBusyLabel(null);
+      }
+    },
+    [handleRequestError, refreshPageData],
+  );
+
+  const handleSubscribe = useCallback(async () => {
+    const trimmedUrl = newFeedUrl.trim();
+    if (!trimmedUrl) {
+      setMutationError('Feed URL is required. Enter a valid RSS or Atom URL and try again.');
+      return;
+    }
+
+    await runMutation('Subscribe feed', async () => {
+      const folderId = newFeedFolderId ? Number(newFeedFolderId) : null;
+      const result = await createFeed(trimmedUrl, folderId);
+
+      setData((current) => ({
+        ...current,
+        feeds: [...current.feeds, result.feed],
+      }));
+      setLatestArticleDates((current) => ({
+        ...current,
+        [result.feed.id]: null,
+      }));
+      setNewFeedUrl('');
+      setNewFeedFolderId('');
+      closeCreateFeedDialog();
+      setStatusMessage(`Subscribed to ${result.feed.title}.`);
+    });
+  }, [closeCreateFeedDialog, newFeedFolderId, newFeedUrl, runMutation]);
+
+  const handleCreateFolder = useCallback(async () => {
+    const trimmedName = newFolderName.trim();
+    if (!trimmedName) {
+      setMutationError('Folder name is required.');
+      return;
+    }
+
+    await runMutation('Create folder', async () => {
+      const createdFolder = await createFolder(trimmedName);
+      setData((current) => ({
+        ...current,
+        folders: [...current.folders, createdFolder],
+      }));
+      setNewFolderName('');
+      createFolderDialogRef.current?.close();
+      setStatusMessage(`Created folder ${createdFolder.name}.`);
+    });
+  }, [newFolderName, runMutation]);
+
+  const handleRenameFolder = useCallback(
+    async (folderId: number) => {
+      const trimmedName = editingFolderName.trim();
+      if (!trimmedName) {
+        setMutationError('Folder name is required.');
+        return;
+      }
+
+      await runMutation('Rename folder', async () => {
+        await renameFolder(folderId, trimmedName);
+        setData((current) => ({
+          ...current,
+          folders: current.folders.map((folder) =>
+            folder.id === folderId ? { ...folder, name: trimmedName } : folder,
+          ),
+        }));
+        setEditingFolderId(null);
+        setEditingFolderName('');
+        setStatusMessage(`Renamed folder to ${trimmedName}.`);
+      });
+    },
+    [editingFolderName, runMutation],
+  );
+
+  const handleDeleteFolder = useCallback(
+    async (folder: Folder) => {
+      const assignedFeeds = data.feeds.filter((feed) => feed.folderId === folder.id);
+      const assignedFeedCount = assignedFeeds.length;
+      const confirmed = window.confirm(
+        `Delete "${folder.name}"? This will unsubscribe ${String(assignedFeedCount)} feed${
+          assignedFeedCount === 1 ? '' : 's'
+        } currently assigned to the folder.`,
+      );
+
+      if (!confirmed) {
+        return;
+      }
+
+      await runMutation('Delete folder', async () => {
+        if (assignedFeeds.length > 0) {
+          const results = await Promise.allSettled(
+            assignedFeeds.map((feed) => deleteFeed(feed.id)),
+          );
+
+          const deletedFeedIds = assignedFeeds
+            .filter((_, index) => results[index].status === 'fulfilled')
+            .map((feed) => feed.id);
+          const failedCount = results.filter((result) => result.status === 'rejected').length;
+
+          if (failedCount > 0) {
+            setData((current) => ({
+              ...current,
+              feeds: current.feeds.filter((feed) => !deletedFeedIds.includes(feed.id)),
+            }));
+            setLatestArticleDates((current) =>
+              deletedFeedIds.reduce(
+                (nextEntries, feedId) => omitLatestArticleDate(nextEntries, feedId),
+                current,
+              ),
+            );
+            throw new Error(
+              `Unable to unsubscribe ${String(failedCount)} feed${failedCount === 1 ? '' : 's'} from "${folder.name}". The folder was not deleted.`,
+            );
+          }
+        }
+
+        await deleteFolder(folder.id);
+        setData((current) => ({
+          folders: current.folders.filter((entry) => entry.id !== folder.id),
+          feeds: current.feeds.filter((feed) => feed.folderId !== folder.id),
+        }));
+        setLatestArticleDates((current) =>
+          assignedFeeds.reduce(
+            (nextEntries, feed) => omitLatestArticleDate(nextEntries, feed.id),
+            current,
+          ),
+        );
+        setStatusMessage(`Deleted folder ${folder.name}.`);
+      });
+    },
+    [data.feeds, runMutation],
+  );
+
+  const handleRenameFeed = useCallback(
+    async (feedId: number) => {
+      const trimmedTitle = editingFeedTitle.trim();
+      if (!trimmedTitle) {
+        setMutationError('Feed name is required.');
+        return;
+      }
+
+      await runMutation('Rename feed', async () => {
+        await renameFeed(feedId, trimmedTitle);
+        setData((current) => ({
+          ...current,
+          feeds: current.feeds.map((feed) =>
+            feed.id === feedId ? { ...feed, title: trimmedTitle } : feed,
+          ),
+        }));
+        setEditingFeedId(null);
+        setEditingFeedTitle('');
+        setStatusMessage(`Renamed feed to ${trimmedTitle}.`);
+      });
+    },
+    [editingFeedTitle, runMutation],
+  );
+
+  const handleMoveFeed = useCallback(
+    async (feedId: number, folderIdValue: string) => {
+      const folderId = folderIdValue ? Number(folderIdValue) : null;
+
+      return runMutation('Move feed', async () => {
+        await moveFeed(feedId, folderId);
+        setData((current) => ({
+          ...current,
+          feeds: current.feeds.map((feed) => (feed.id === feedId ? { ...feed, folderId } : feed)),
+        }));
+        setStatusMessage('Moved feed successfully.');
+      });
+    },
+    [runMutation],
+  );
+
+  const handleMoveFeedSubmit = useCallback(async () => {
+    if (moveFeedId === null) {
+      return;
+    }
+
+    const moved = await handleMoveFeed(moveFeedId, moveFeedFolderId);
+    if (moved) {
+      moveFeedDialogRef.current?.close();
+      resetMoveFeedDialog();
+    }
+  }, [handleMoveFeed, moveFeedFolderId, moveFeedId, resetMoveFeedDialog]);
+
+  const handleDeleteFeed = useCallback(
+    async (feed: Feed) => {
+      const confirmed = window.confirm(`Unsubscribe "${feed.title}"?`);
+      if (!confirmed) {
+        return;
+      }
+
+      await runMutation('Delete feed', async () => {
+        await deleteFeed(feed.id);
+        setData((current) => ({
+          ...current,
+          feeds: current.feeds.filter((entry) => entry.id !== feed.id),
+        }));
+        setLatestArticleDates((current) => omitLatestArticleDate(current, feed.id));
+        setStatusMessage(`Unsubscribed from ${feed.title}.`);
+      });
+    },
+    [runMutation],
+  );
+
+  return {
+    isAuthenticated,
+    isInitializing,
+    isLoading,
+    isRefreshing,
+    data,
+    groups,
+    sortedFolders,
+    busyLabel,
+    pageError,
+    mutationError,
+    statusMessage,
+    createFeedDialogRef,
+    createFolderDialogRef,
+    moveFeedDialogRef,
+    newFeedUrl,
+    setNewFeedUrl,
+    newFeedFolderId,
+    setNewFeedFolderId,
+    newFolderName,
+    setNewFolderName,
+    editingFolderId,
+    setEditingFolderId,
+    editingFolderName,
+    setEditingFolderName,
+    editingFeedId,
+    setEditingFeedId,
+    editingFeedTitle,
+    setEditingFeedTitle,
+    moveFeedTitle,
+    moveFeedFolderId,
+    setMoveFeedFolderId,
+    openCreateFeedDialog,
+    closeCreateFeedDialog,
+    openMoveFeedDialog,
+    resetMoveFeedDialog,
+    refreshPageData,
+    handleSubscribe,
+    handleCreateFolder,
+    handleRenameFolder,
+    handleDeleteFolder,
+    handleRenameFeed,
+    handleMoveFeedSubmit,
+    handleDeleteFeed,
+  };
+}

--- a/src/hooks/useLoginFlow.ts
+++ b/src/hooks/useLoginFlow.ts
@@ -1,0 +1,102 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  getLoginServerError,
+  validateLoginCredentials,
+  validateLoginServerUrl,
+  validateServerConnectivity,
+} from '@/lib/auth/login';
+
+export enum LoginStep {
+  SERVER_URL = 1,
+  VALIDATING_URL = 2,
+  CREDENTIALS = 3,
+  AUTHENTICATING = 4,
+}
+
+/**
+ * Owns the login wizard/plain-form state machine.
+ */
+export function useLoginFlow() {
+  const router = useRouter();
+  const { login, error } = useAuth();
+  const [step, setStep] = useState<LoginStep>(LoginStep.SERVER_URL);
+  const [serverUrl, setServerUrl] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [rememberDevice, setRememberDevice] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleServerUrlSubmit = useCallback(async () => {
+    setValidationError(null);
+
+    try {
+      const { normalized } = validateLoginServerUrl(serverUrl);
+      setStep(LoginStep.VALIDATING_URL);
+      await validateServerConnectivity(normalized);
+      setServerUrl(normalized);
+      setStep(LoginStep.CREDENTIALS);
+    } catch (error) {
+      setStep(LoginStep.SERVER_URL);
+      setValidationError(getLoginServerError(error));
+    }
+  }, [serverUrl]);
+
+  const handleCredentialsSubmit = useCallback(async () => {
+    setValidationError(null);
+
+    try {
+      validateLoginCredentials(username, password);
+      setStep(LoginStep.AUTHENTICATING);
+      await login(serverUrl, username, password, rememberDevice);
+      router.push('/timeline');
+    } catch (error) {
+      setStep(LoginStep.CREDENTIALS);
+      setValidationError(error instanceof Error ? error.message : 'Authentication failed');
+    }
+  }, [login, password, rememberDevice, router, serverUrl, username]);
+
+  const handlePlainSubmit = useCallback(async () => {
+    setValidationError(null);
+
+    try {
+      const { normalized } = validateLoginServerUrl(serverUrl);
+      validateLoginCredentials(username, password);
+      setStep(LoginStep.AUTHENTICATING);
+      await validateServerConnectivity(normalized);
+      await login(normalized, username, password, rememberDevice);
+      router.push('/timeline');
+    } catch (error) {
+      setStep(LoginStep.SERVER_URL);
+      setValidationError(getLoginServerError(error));
+    }
+  }, [login, password, rememberDevice, router, serverUrl, username]);
+
+  const handleBack = useCallback(() => {
+    setValidationError(null);
+    if (step === LoginStep.CREDENTIALS) {
+      setStep(LoginStep.SERVER_URL);
+    }
+  }, [step]);
+
+  return {
+    step,
+    serverUrl,
+    setServerUrl,
+    username,
+    setUsername,
+    password,
+    setPassword,
+    rememberDevice,
+    setRememberDevice,
+    validationError,
+    authError: error,
+    handleServerUrlSubmit,
+    handleCredentialsSubmit,
+    handlePlainSubmit,
+    handleBack,
+  };
+}

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import { getFolders } from '@/lib/api/folders';
 import { getFeeds } from '@/lib/api/feeds';
 import { markItemsRead, markItemRead as apiMarkItemRead } from '@/lib/api/items';
-import { fetchUnreadItemsForSync, reconcileTimelineCache } from '@/lib/sync';
+import { fetchUnreadItemsForSync } from '@/lib/api/itemsSync';
+import { reconcileTimelineCache } from '@/lib/storage/timelineCache';
 import {
   deriveFolderProgress,
   moveFolderToEnd,
@@ -13,7 +14,6 @@ import {
   sortFolderQueueEntries,
 } from '@/lib/utils/unreadAggregator';
 import {
-  type Article,
   type ArticlePreview,
   type Folder,
   type FolderProgressState,
@@ -29,11 +29,14 @@ import {
   storeTimelineCache,
 } from '@/lib/storage';
 import {
-  getNextSelectionId,
-  getPreviousSelectionId,
-  getTopmostVisibleId,
-} from '@/lib/timeline/selection';
-import { createReadBatcher } from '@/lib/timeline/read-batching';
+  applyFeedNames,
+  applyFolderNames,
+  resolveFolderId,
+  toArticlePreview,
+} from '@/lib/timeline/articlePreview';
+import { buildFolderMap, findNextActiveId } from '@/lib/timeline/envelope';
+import { useTimelineSelection } from '@/hooks/useTimelineSelection';
+import { useAutoMarkRead } from '@/hooks/useAutoMarkRead';
 
 type FeedsSummary = Awaited<ReturnType<typeof getFeeds>>;
 
@@ -72,87 +75,8 @@ interface RefreshOptions {
   forceSync?: boolean;
 }
 
-function stripHtml(input: string): string {
-  if (!input) return '';
-  return input
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function summarize(body: string, fallback: string): string {
-  const text = stripHtml(body);
-  if (!text) return fallback;
-  return text.length > 320 ? `${text.slice(0, 317).trim()}…` : text;
-}
-
-function resolveFolderId(article: Article, feedFolderMap: Map<number, number>): number | null {
-  if (typeof article.folderId === 'number' && Number.isFinite(article.folderId)) {
-    return article.folderId;
-  }
-
-  if (feedFolderMap.has(article.feedId)) {
-    return feedFolderMap.get(article.feedId) ?? UNCATEGORIZED_FOLDER_ID;
-  }
-
-  return null;
-}
-
-function toArticlePreview(
-  article: Article,
-  folderId: number | null,
-  cachedAt: number,
-  feedName: string,
-): ArticlePreview | null {
-  if (folderId === null) {
-    return null;
-  }
-  const trimmedTitle = article.title.trim();
-  const fallbackTitle = trimmedTitle.length > 0 ? article.title : 'Untitled article';
-  const summary = summarize(article.body, '');
-  const trimmedBody = article.body.trim();
-  const trimmedUrl = article.url.trim();
-  const hasFullText = trimmedBody.length > 0;
-  const trimmedAuthor = article.author.trim();
-  const normalizedFeedName = feedName.trim();
-
-  return {
-    id: article.id,
-    folderId,
-    feedId: article.feedId,
-    title: fallbackTitle,
-    feedName: normalizedFeedName.length > 0 ? normalizedFeedName : 'Unknown source',
-    author: trimmedAuthor,
-    summary,
-    body: trimmedBody,
-    url: trimmedUrl.length > 0 ? article.url : '#',
-    thumbnailUrl: article.mediaThumbnail,
-    pubDate: article.pubDate,
-    unread: article.unread,
-    starred: article.starred,
-    hasFullText,
-    storedAt: cachedAt,
-  };
-}
-
-function buildFolderMap(entries: FolderQueueEntry[]): Record<number, FolderQueueEntry> {
-  return entries.reduce<Record<number, FolderQueueEntry>>((acc, entry) => {
-    acc[entry.id] = entry;
-    return acc;
-  }, {});
-}
-
-function findNextActiveId(queue: FolderQueueEntry[]): number | null {
-  const nextActive = queue.find((entry) => entry.status !== 'skipped');
-  return nextActive ? nextActive.id : null;
-}
-
 const SYNC_TIMEOUT_MS = 8000;
 const MIN_SYNC_INDICATOR_MS = 350;
-// Delay before re-enabling the IntersectionObserver after programmatic scroll.
-// This prevents articles from being marked as read during the scroll animation.
-// 500ms is sufficient for most scroll animations to complete.
-const OBSERVER_RE_ENABLE_DELAY_MS = 500;
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -173,63 +97,6 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
       clearTimeout(timeoutId);
     }
   }
-}
-
-function applyFolderNames(
-  envelope: TimelineCacheEnvelope,
-  foldersData: Folder[] | undefined,
-): TimelineCacheEnvelope {
-  if (!foldersData || foldersData.length === 0) {
-    return envelope;
-  }
-
-  const folderNameMap = new Map<number, string>(
-    foldersData.map((folder) => [folder.id, folder.name]),
-  );
-  const updatedFolders: Record<number, FolderQueueEntry> = {};
-
-  for (const [folderIdStr, folder] of Object.entries(envelope.folders)) {
-    const id = Number(folderIdStr);
-    const resolvedName =
-      folderNameMap.get(id) ?? (id === UNCATEGORIZED_FOLDER_ID ? 'Uncategorized' : folder.name);
-    updatedFolders[id] = {
-      ...folder,
-      name: resolvedName,
-    };
-  }
-
-  return {
-    ...envelope,
-    folders: updatedFolders,
-  };
-}
-
-function applyFeedNames(
-  envelope: TimelineCacheEnvelope,
-  feedNameMap: Map<number, string>,
-): TimelineCacheEnvelope {
-  if (feedNameMap.size === 0) {
-    return envelope;
-  }
-
-  const updatedFolders: Record<number, FolderQueueEntry> = {};
-
-  for (const [folderIdStr, folder] of Object.entries(envelope.folders)) {
-    const updatedArticles = folder.articles.map((article) => {
-      const resolvedName = feedNameMap.get(article.feedId) ?? article.feedName;
-      return resolvedName !== article.feedName ? { ...article, feedName: resolvedName } : article;
-    });
-
-    updatedFolders[Number(folderIdStr)] = {
-      ...folder,
-      articles: updatedArticles,
-    };
-  }
-
-  return {
-    ...envelope,
-    folders: updatedFolders,
-  };
 }
 
 /**
@@ -597,138 +464,23 @@ export function useTimeline(options: UseTimelineOptions = {}): UseTimelineResult
     }
   }, []);
 
-  const [selectedArticleId, setSelectedArticleId] = useState<number | null>(null);
-  const [selectedArticleElement, setSelectedArticleElement] = useState<HTMLElement | null>(null);
-
-  const orderedIds = useMemo(() => activeArticles.map((article) => article.id), [activeArticles]);
-
-  const selectTopmost = useCallback(
-    (topmostId?: number | null) => {
-      const resolvedId = topmostId ?? getTopmostVisibleId(orderedIds);
-      if (resolvedId === null || typeof resolvedId === 'undefined') return;
-      setSelectedArticleId(resolvedId);
-    },
-    [orderedIds],
-  );
-
-  const selectNext = useCallback(() => {
-    const nextId = getNextSelectionId(selectedArticleId, orderedIds);
-    if (nextId === null) return;
-    setSelectedArticleId(nextId);
-  }, [orderedIds, selectedArticleId]);
-
-  const selectPrevious = useCallback(() => {
-    const prevId = getPreviousSelectionId(selectedArticleId, orderedIds);
-    if (prevId === null) return;
-    setSelectedArticleId(prevId);
-  }, [orderedIds, selectedArticleId]);
-
-  const deselect = useCallback(() => {
-    setSelectedArticleId(null);
-    setSelectedArticleElement(null);
-  }, []);
-
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const elementsRef = useRef<Map<number, HTMLElement>>(new Map());
-  const seenRef = useRef<Set<number>>(new Set());
-  const batcherRef = useRef<ReturnType<typeof createReadBatcher> | null>(null);
-  const unreadMapRef = useRef<Map<number, boolean>>(new Map());
-  const observerDisabledRef = useRef(false);
-  const observerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    batcherRef.current?.clear();
-    batcherRef.current = createReadBatcher({
-      debounceMs: debounceMs,
-      onFlush: (ids) => {
-        ids.forEach((id) => {
-          void markItemRead(id);
-        });
-      },
-    });
-
-    return () => {
-      batcherRef.current?.clear();
-      batcherRef.current = null;
-      // Clean up any pending observer timeout
-      if (observerTimeoutRef.current !== null) {
-        clearTimeout(observerTimeoutRef.current);
-        observerTimeoutRef.current = null;
-      }
-    };
-  }, [debounceMs, markItemRead]);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        // Skip processing if observer is temporarily disabled
-        if (observerDisabledRef.current) return;
-
-        entries.forEach((entry) => {
-          const target = entry.target as HTMLElement;
-          const id = Number(target.dataset.articleId);
-          if (!Number.isFinite(id)) return;
-
-          if (!entry.isIntersecting && entry.boundingClientRect.bottom <= 0) {
-            if (seenRef.current.has(id)) return;
-            if (unreadMapRef.current.get(id) === false) return;
-            seenRef.current.add(id);
-            batcherRef.current?.add(id);
-          }
-        });
-      },
-      {
-        root: root ?? null,
-        rootMargin: `${String(-Math.max(0, Math.round(topOffset)))}px 0px 0px 0px`,
-        threshold: [0],
-      },
-    );
-
-    observerRef.current = observer;
-    elementsRef.current.forEach((node) => {
-      observer.observe(node);
-    });
-
-    return () => {
-      observer.disconnect();
-      observerRef.current = null;
-    };
-  }, [root, topOffset]);
-
-  useEffect(() => {
-    unreadMapRef.current = new Map(activeArticles.map((item) => [item.id, item.unread]));
-    const currentIds = new Set(activeArticles.map((item) => item.id));
-    for (const [id, element] of elementsRef.current.entries()) {
-      if (!currentIds.has(id)) {
-        observerRef.current?.unobserve(element);
-        elementsRef.current.delete(id);
-        seenRef.current.delete(id);
-      }
-    }
-  }, [activeArticles]);
-
-  const registerArticle = useCallback(
-    (id: number) => (node: HTMLElement | null) => {
-      if (!node) return;
-      node.dataset.articleId = String(id);
-      elementsRef.current.set(id, node);
-      observerRef.current?.observe(node);
-    },
-    [],
-  );
-
-  const disableObserverTemporarily = useCallback(() => {
-    observerDisabledRef.current = true;
-    // Clear any existing timeout
-    if (observerTimeoutRef.current !== null) {
-      clearTimeout(observerTimeoutRef.current);
-    }
-    // Re-enable after a short delay to allow scroll to complete
-    observerTimeoutRef.current = setTimeout(() => {
-      observerDisabledRef.current = false;
-      observerTimeoutRef.current = null;
-    }, OBSERVER_RE_ENABLE_DELAY_MS);
-  }, []);
+  const {
+    selectedArticleId,
+    setSelectedArticleId,
+    selectedArticleElement,
+    setSelectedArticleElement,
+    selectTopmost,
+    selectNext,
+    selectPrevious,
+    deselect,
+  } = useTimelineSelection(activeArticles);
+  const { registerArticle, disableObserverTemporarily } = useAutoMarkRead({
+    activeArticles,
+    markItemRead,
+    root,
+    topOffset,
+    debounceMs,
+  });
 
   return {
     queue: orderedQueue,

--- a/src/hooks/useTimelineSelection.ts
+++ b/src/hooks/useTimelineSelection.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { ArticlePreview, SelectionActions } from '@/types';
+import {
+  getNextSelectionId,
+  getPreviousSelectionId,
+  getTopmostVisibleId,
+} from '@/lib/timeline/selection';
+
+export interface TimelineSelectionState extends SelectionActions {
+  selectedArticleId: number | null;
+  setSelectedArticleId: (id: number | null) => void;
+  selectedArticleElement: HTMLElement | null;
+  setSelectedArticleElement: (element: HTMLElement | null) => void;
+}
+
+/**
+ * Owns keyboard/focus selection state for the active timeline folder.
+ */
+export function useTimelineSelection(activeArticles: ArticlePreview[]): TimelineSelectionState {
+  const [selectedArticleId, setSelectedArticleId] = useState<number | null>(null);
+  const [selectedArticleElement, setSelectedArticleElement] = useState<HTMLElement | null>(null);
+
+  const orderedIds = useMemo(() => activeArticles.map((article) => article.id), [activeArticles]);
+
+  const selectTopmost = useCallback(
+    (topmostId?: number | null) => {
+      const resolvedId = topmostId ?? getTopmostVisibleId(orderedIds);
+      if (resolvedId === null || typeof resolvedId === 'undefined') return;
+      setSelectedArticleId(resolvedId);
+    },
+    [orderedIds],
+  );
+
+  const selectNext = useCallback(() => {
+    const nextId = getNextSelectionId(selectedArticleId, orderedIds);
+    if (nextId === null) return;
+    setSelectedArticleId(nextId);
+  }, [orderedIds, selectedArticleId]);
+
+  const selectPrevious = useCallback(() => {
+    const previousId = getPreviousSelectionId(selectedArticleId, orderedIds);
+    if (previousId === null) return;
+    setSelectedArticleId(previousId);
+  }, [orderedIds, selectedArticleId]);
+
+  const deselect = useCallback(() => {
+    setSelectedArticleId(null);
+    setSelectedArticleElement(null);
+  }, []);
+
+  return {
+    selectedArticleId,
+    setSelectedArticleId,
+    selectedArticleElement,
+    setSelectedArticleElement,
+    selectTopmost,
+    selectNext,
+    selectPrevious,
+    deselect,
+  };
+}

--- a/src/lib/auth/login.ts
+++ b/src/lib/auth/login.ts
@@ -1,0 +1,75 @@
+import { ApiError, NetworkError } from '@/lib/api/client';
+import { getVersion } from '@/lib/api/version';
+import { normalizeBaseUrl, validateServerUrl } from '@/lib/config/env';
+
+export interface ValidatedServerUrl {
+  raw: string;
+  normalized: string;
+}
+
+/**
+ * Validates and normalizes a server URL entered during login.
+ */
+export function validateLoginServerUrl(rawValue: string): ValidatedServerUrl {
+  const raw = rawValue.trim();
+  if (!raw) {
+    throw new Error('Server URL is required');
+  }
+
+  const validation = validateServerUrl(raw);
+  if (!validation.valid) {
+    throw new Error(validation.error ?? 'Please enter a valid server URL.');
+  }
+
+  const normalized = normalizeBaseUrl(raw);
+  if (!normalized) {
+    throw new Error('Please enter a valid URL');
+  }
+
+  return { raw, normalized };
+}
+
+/**
+ * Validates the username/password fields entered during login.
+ */
+export function validateLoginCredentials(username: string, password: string): void {
+  if (!username.trim()) {
+    throw new Error('Username is required');
+  }
+
+  if (!password) {
+    throw new Error('Password is required');
+  }
+}
+
+/**
+ * Maps connectivity failures to user-facing login validation copy.
+ */
+export function getLoginServerError(error: unknown): string {
+  if (error instanceof NetworkError) {
+    return error.message;
+  }
+
+  if (error instanceof ApiError) {
+    if (error.status === 404) {
+      return 'Server not found or invalid API endpoint. Please verify the URL.';
+    }
+    if (error.status >= 500) {
+      return 'Server error. Please try again later.';
+    }
+    return `Server returned error: ${error.statusText}`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unable to validate server. Please check your connection.';
+}
+
+/**
+ * Validates server connectivity through the unauthenticated version endpoint.
+ */
+export async function validateServerConnectivity(serverUrl: string): Promise<void> {
+  await getVersion(serverUrl);
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_PREFERENCES, type StoredSession, type UserSessionConfig } from '@/types';
+
+/**
+ * Encodes username and password for HTTP Basic authentication.
+ */
+export function encodeBasicCredentials(username: string, password: string): string {
+  return btoa(`${username}:${password}`);
+}
+
+/**
+ * Converts minimal persisted session data into the richer in-memory session shape.
+ */
+export function toUserSessionConfig(stored: StoredSession): UserSessionConfig {
+  return {
+    baseUrl: stored.baseUrl,
+    username: stored.username,
+    credentials: stored.credentials,
+    rememberDevice: stored.rememberDevice,
+    ...DEFAULT_PREFERENCES,
+    lastSyncAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Strips in-memory-only fields before persisting a session.
+ */
+export function toStoredSession(session: UserSessionConfig): StoredSession {
+  return {
+    baseUrl: session.baseUrl,
+    username: session.username,
+    credentials: session.credentials,
+    rememberDevice: session.rememberDevice,
+  };
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -5,6 +5,7 @@
 
 import { CONFIG } from './config/env';
 import { type StoredSession, type UserPreferences, DEFAULT_PREFERENCES } from '@/types';
+import { encodeBasicCredentials } from '@/lib/auth/session';
 
 /**
  * Stores session data in the appropriate storage based on rememberDevice flag.
@@ -121,7 +122,7 @@ export function clearAllData(): void {
  * Encodes credentials for HTTP Basic auth.
  */
 export function encodeCredentials(username: string, password: string): string {
-  return btoa(`${username}:${password}`);
+  return encodeBasicCredentials(username, password);
 }
 
 /**

--- a/src/lib/sync/index.ts
+++ b/src/lib/sync/index.ts
@@ -1,2 +1,0 @@
-export { fetchUnreadItemsForSync } from '@/lib/api/itemsSync';
-export { reconcileTimelineCache } from '@/lib/storage/timelineCache';

--- a/src/lib/timeline/articlePreview.ts
+++ b/src/lib/timeline/articlePreview.ts
@@ -1,0 +1,139 @@
+import type {
+  Article,
+  ArticlePreview,
+  Folder,
+  FolderQueueEntry,
+  TimelineCacheEnvelope,
+} from '@/types';
+import { UNCATEGORIZED_FOLDER_ID } from '@/types';
+
+function stripHtml(input: string): string {
+  if (!input) return '';
+  return input
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function summarize(body: string, fallback: string): string {
+  const text = stripHtml(body);
+  if (!text) return fallback;
+  return text.length > 320 ? `${text.slice(0, 317).trim()}...` : text;
+}
+
+/**
+ * Resolves the folder ID for a server article using either direct article data or feed metadata.
+ */
+export function resolveFolderId(
+  article: Article,
+  feedFolderMap: Map<number, number>,
+): number | null {
+  if (typeof article.folderId === 'number' && Number.isFinite(article.folderId)) {
+    return article.folderId;
+  }
+
+  if (feedFolderMap.has(article.feedId)) {
+    return feedFolderMap.get(article.feedId) ?? UNCATEGORIZED_FOLDER_ID;
+  }
+
+  return null;
+}
+
+/**
+ * Normalizes a full article payload into the cached preview shape used by the timeline.
+ */
+export function toArticlePreview(
+  article: Article,
+  folderId: number | null,
+  cachedAt: number,
+  feedName: string,
+): ArticlePreview | null {
+  if (folderId === null) {
+    return null;
+  }
+
+  const trimmedTitle = article.title.trim();
+  const trimmedBody = article.body.trim();
+  const trimmedUrl = article.url.trim();
+  const trimmedAuthor = article.author.trim();
+  const normalizedFeedName = feedName.trim();
+
+  return {
+    id: article.id,
+    folderId,
+    feedId: article.feedId,
+    title: trimmedTitle.length > 0 ? article.title : 'Untitled article',
+    feedName: normalizedFeedName.length > 0 ? normalizedFeedName : 'Unknown source',
+    author: trimmedAuthor,
+    summary: summarize(article.body, ''),
+    body: trimmedBody,
+    url: trimmedUrl.length > 0 ? article.url : '#',
+    thumbnailUrl: article.mediaThumbnail,
+    pubDate: article.pubDate,
+    unread: article.unread,
+    starred: article.starred,
+    hasFullText: trimmedBody.length > 0,
+    storedAt: cachedAt,
+  };
+}
+
+/**
+ * Reconciles cached folder names with the latest folder metadata.
+ */
+export function applyFolderNames(
+  envelope: TimelineCacheEnvelope,
+  foldersData: Folder[] | undefined,
+): TimelineCacheEnvelope {
+  if (!foldersData || foldersData.length === 0) {
+    return envelope;
+  }
+
+  const folderNameMap = new Map<number, string>(
+    foldersData.map((folder) => [folder.id, folder.name]),
+  );
+  const updatedFolders: Record<number, FolderQueueEntry> = {};
+
+  for (const [folderIdStr, folder] of Object.entries(envelope.folders)) {
+    const id = Number(folderIdStr);
+    const resolvedName =
+      folderNameMap.get(id) ?? (id === UNCATEGORIZED_FOLDER_ID ? 'Uncategorized' : folder.name);
+    updatedFolders[id] = {
+      ...folder,
+      name: resolvedName,
+    };
+  }
+
+  return {
+    ...envelope,
+    folders: updatedFolders,
+  };
+}
+
+/**
+ * Reconciles cached feed names with the latest feed metadata.
+ */
+export function applyFeedNames(
+  envelope: TimelineCacheEnvelope,
+  feedNameMap: Map<number, string>,
+): TimelineCacheEnvelope {
+  if (feedNameMap.size === 0) {
+    return envelope;
+  }
+
+  const updatedFolders: Record<number, FolderQueueEntry> = {};
+
+  for (const [folderIdStr, folder] of Object.entries(envelope.folders)) {
+    updatedFolders[Number(folderIdStr)] = {
+      ...folder,
+      articles: folder.articles.map((article) => {
+        const resolvedName = feedNameMap.get(article.feedId) ?? article.feedName;
+        return resolvedName !== article.feedName ? { ...article, feedName: resolvedName } : article;
+      }),
+    };
+  }
+
+  return {
+    ...envelope,
+    folders: updatedFolders,
+  };
+}

--- a/src/lib/timeline/envelope.ts
+++ b/src/lib/timeline/envelope.ts
@@ -1,0 +1,19 @@
+import type { FolderQueueEntry } from '@/types';
+
+/**
+ * Rebuilds the folder record from the ordered queue representation.
+ */
+export function buildFolderMap(entries: FolderQueueEntry[]): Record<number, FolderQueueEntry> {
+  return entries.reduce<Record<number, FolderQueueEntry>>((acc, entry) => {
+    acc[entry.id] = entry;
+    return acc;
+  }, {});
+}
+
+/**
+ * Returns the next non-skipped folder ID to activate.
+ */
+export function findNextActiveId(queue: FolderQueueEntry[]): number | null {
+  const nextActive = queue.find((entry) => entry.status !== 'skipped');
+  return nextActive ? nextActive.id : null;
+}

--- a/tests/unit/hooks/useTimeline.test.tsx
+++ b/tests/unit/hooks/useTimeline.test.tsx
@@ -12,8 +12,7 @@ const mocks = vi.hoisted(() => ({
   unreadItems: [] as Article[],
 }));
 
-vi.mock('@/lib/sync', async () => {
-  const actual = await import('@/lib/sync');
+vi.mock('@/lib/api/itemsSync', () => {
   return {
     fetchUnreadItemsForSync: vi.fn(() =>
       Promise.resolve({
@@ -21,6 +20,13 @@ vi.mock('@/lib/sync', async () => {
         serverUnreadIds: new Set(mocks.unreadItems.map((item) => item.id)),
       }),
     ),
+  };
+});
+
+vi.mock('@/lib/storage/timelineCache', async () => {
+  const actual = await import('@/lib/storage/timelineCache');
+  return {
+    ...actual,
     reconcileTimelineCache: actual.reconcileTimelineCache,
   };
 });


### PR DESCRIPTION
- Added `useFeedManagementPage` hook for managing feeds and folders, including CRUD operations and state management.
- Introduced `useLoginFlow` hook to handle the login process with server URL validation and credential submission.
- Refactored timeline-related hooks by creating `useTimelineSelection` for managing article selection state.
- Updated `useTimeline` to integrate new selection and auto-mark read functionalities.
- Created utility functions for validating login server URLs and credentials in `login.ts`.
- Added session management functions in `session.ts` for encoding credentials and converting session data.
- Implemented article preview utilities in `articlePreview.ts` for normalizing article data and reconciling folder/feed names.
- Removed deprecated sync module and adjusted related tests to reflect changes in API structure.